### PR TITLE
Fix issues where emoji are sometimes treated as 2 characters

### DIFF
--- a/dist/limitCharacts.js
+++ b/dist/limitCharacts.js
@@ -12,8 +12,10 @@
 function limitCharacts(limitField, limitNum) {
     "use strict";
     function limiter(elem, countElem) {
-        if (elem.value.length > limitNum) elem.value = elem.value.substring(0, limitNum); else {
-            var currentCount = limitNum - elem.value.length;
+        var pairs = elem.value.split(/([\uD800-\uDBFF][\uDC00-\uDFFF])/), chars = [], elemLength = 0;
+        for (var p in pairs) "" !== pairs[p] && (null !== pairs[p].match(/([\uD800-\uDBFF][\uDC00-\uDFFF])/) ? chars.push(pairs[p]) : chars = chars.concat(pairs[p].split("")));
+        if (elemLength = chars.length, elemLength > limitNum) elem.value = chars.splice(0, limitNum).join(""); else {
+            var currentCount = limitNum - elemLength;
             valueCountElem(countElem, currentCount);
         }
     }

--- a/dist/limitCharacts.min.js
+++ b/dist/limitCharacts.min.js
@@ -9,4 +9,4 @@
  *  License: MIT
  *  ©2015
  */
-function limitCharacts(a,b){"use strict";function c(a,c){if(a.value.length>b)a.value=a.value.substring(0,b);else{var e=b-a.value.length;d(c,e)}}function d(a,b){a instanceof HTMLInputElement&&"text"===a.type?a.value=b:a.textContent=b}a.length&&[].forEach.call(a,function(a){var e=a.getAttribute("data-count"),f=document.querySelector(e);d(f,b),a.addEventListener("keydown",function(){c(a,f)}),a.addEventListener("keyup",function(){c(a,f)})})}
+function limitCharacts(a,b){"use strict";function c(a,c){var e=a.value.split(/([\uD800-\uDBFF][\uDC00-\uDFFF])/),f=[],g=0;for(var h in e)""!==e[h]&&(null!==e[h].match(/([\uD800-\uDBFF][\uDC00-\uDFFF])/)?f.push(e[h]):f=f.concat(e[h].split("")));if(g=f.length,g>b)a.value=f.splice(0,b).join("");else{var i=b-g;d(c,i)}}function d(a,b){a instanceof HTMLInputElement&&"text"===a.type?a.value=b:a.textContent=b}a.length&&[].forEach.call(a,function(a){var e=a.getAttribute("data-count"),f=document.querySelector(e);d(f,b),a.addEventListener("keydown",function(){c(a,f)}),a.addEventListener("keyup",function(){c(a,f)})})}

--- a/src/limitCharacts.js
+++ b/src/limitCharacts.js
@@ -22,10 +22,30 @@ function limitCharacts(limitField, limitNum) {
   }
 
   function limiter(elem,countElem){
-    if (elem.value.length > limitNum) {
-      elem.value = elem.value.substring(0, limitNum);
+    // split on surrogate pairs and preserve surrogates. this plays
+    // nicely with emoji and other unicode characters
+    var pairs = elem.value.split(/([\uD800-\uDBFF][\uDC00-\uDFFF])/),
+      chars = [],
+      elemLength = 0;
+    // create a set of pairs. splits the emoji information out but
+    // non-emoji strings get lumped together
+    for (var p in pairs) {
+      if (pairs[p] === "") {
+        continue;
+      }
+      if (pairs[p].match(/([\uD800-\uDBFF][\uDC00-\uDFFF])/) !== null) {
+        // push emoji and treat as 1 character
+        chars.push(pairs[p]);
+      } else {
+        // non-emoji, split and add to the array
+        chars = chars.concat(pairs[p].split(""));
+      }
+    }
+    elemLength = chars.length;
+    if (elemLength > limitNum) {
+      elem.value = chars.splice(0, limitNum).join("");
     } else {
-      var currentCount = limitNum - elem.value.length;
+      var currentCount = limitNum - elemLength;
       valueCountElem(countElem,currentCount);
     }
   }


### PR DESCRIPTION
Emoji characters are a pain! And some of them are being counted as 2 characters. The upshot of this is that: a. they cost more than a single character, and b. they can be split in half when limiting the textarea contents.

This pull requests fixes this issue and treats all emoji (regardless of byte-length) as a single character.
